### PR TITLE
Fix build phase script error under Xcode 9 GM

### DIFF
--- a/Sources/PBXShellScriptBuildPhase.swift
+++ b/Sources/PBXShellScriptBuildPhase.swift
@@ -20,7 +20,7 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
 
     /// Shell script.
     public var shellScript: String?
-    
+
     /// Show environment variables in the logs.
     public var showEnvVarsInLog: UInt?
 
@@ -41,7 +41,7 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
                 name: String? = nil,
                 inputPaths: [String],
                 outputPaths: [String],
-                shellPath: String = "bin/sh",
+                shellPath: String = "/bin/sh",
                 shellScript: String?,
                 buildActionMask: UInt = 2147483647,
                 runOnlyForDeploymentPostprocessing: UInt = 0,


### PR DESCRIPTION
### Short description
> Describe here the purpose of your PR.

It seems under Xcode 9 build will fail if shell path is `bin/sh`.

### Solution
> Describe the solution you came up with and the reasons that led you to that solution. If you thought about other solutions don't forget about mentioning them.

Make it `/bin/sh`.

### Implementation
> Detail in a checklist the steps that you took to implement the PR.

- [x] Generate a basic project with inline build shell script with `xcodegen`.
- [x] Copy the project and recreate that build shell script phase manually with Xcode and did diff with original.
- [x] Turned out that the project cannot be built because of shell path.