### PR TITLE
Add PBXReferenceProxy object

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AEXML",
+        "repositoryURL": "https://github.com/tadija/AEXML.git",
+        "state": {
+          "branch": null,
+          "revision": "2981eccd86a69ea12a7f71a4c6b4d5177c2972a9",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "package": "PathKit",
+        "repositoryURL": "https://github.com/kylef/PathKit.git",
+        "state": {
+          "branch": null,
+          "revision": "891a3fec2699fc43aed18b7649950677c0152a22",
+          "version": "0.8.0"
+        }
+      },
+      {
+        "package": "Spectre",
+        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "state": {
+          "branch": null,
+          "revision": "e46b75cf03ad5e563b4b0a5068d3d6f04d77d80b",
+          "version": "0.7.2"
+        }
+      },
+      {
+        "package": "Unbox",
+        "repositoryURL": "https://github.com/JohnSundell/Unbox.git",
+        "state": {
+          "branch": null,
+          "revision": "17ad6aa1cc2f1efa27a0bbbdb66f79796708aa95",
+          "version": "2.5.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sources/xcodeproj/PBXObject.swift
+++ b/Sources/xcodeproj/PBXObject.swift
@@ -65,6 +65,8 @@ public class PBXObject: Referenceable {
             return try PBXCopyFilesBuildPhase(reference: reference, dictionary: dictionary)
         case PBXContainerItemProxy.isa:
             return try PBXContainerItemProxy(reference: reference, dictionary: dictionary)
+        case PBXReferenceProxy.isa:
+            return try PBXReferenceProxy(reference: reference, dictionary: dictionary)
         default:
             throw PBXObjectError.unknownElement(isa)
         }

--- a/Sources/xcodeproj/PBXProj.swift
+++ b/Sources/xcodeproj/PBXProj.swift
@@ -38,7 +38,8 @@ public class PBXProj {
     public var nativeTargets: [PBXNativeTarget] = []
     public var fileReferences: [PBXFileReference] = []
     public var projects: [PBXProject] = []
-
+    public var referenceProxies: [PBXReferenceProxy] = []
+    
     /// Initializes the project with its attributes.
     ///
     /// - Parameters:
@@ -81,6 +82,7 @@ public class PBXProj {
             array += fileReferences as [PBXObject]
             array += projects as [PBXObject]
             array += versionGroups as [PBXObject]
+            array += referenceProxies as [PBXObject]
             return array
         }
         set {
@@ -103,6 +105,7 @@ public class PBXProj {
             fileReferences = newValue.flatMap { $0 as? PBXFileReference }
             projects = newValue.flatMap { $0 as? PBXProject }
             versionGroups = newValue.flatMap { $0 as? XCVersionGroup }
+            referenceProxies = newValue.flatMap { $0 as? PBXReferenceProxy }
         }
     }
 
@@ -127,6 +130,7 @@ public class PBXProj {
         case let object as PBXFileReference: fileReferences.append(object)
         case let object as PBXProject: projects.append(object)
         case let object as XCVersionGroup: versionGroups.append(object)
+        case let object as PBXReferenceProxy: referenceProxies.append(object)
         default: break
         }
     }
@@ -194,6 +198,7 @@ extension PBXProj: Equatable {
             lhs.fileReferences == rhs.fileReferences &&
             lhs.projects == rhs.projects &&
             lhs.rootObject == rhs.rootObject &&
-            lhs.versionGroups == rhs.versionGroups
+            lhs.versionGroups == rhs.versionGroups &&
+            lhs.referenceProxies == rhs.referenceProxies
     }
 }

--- a/Sources/xcodeproj/PBXReferenceProxy.swift
+++ b/Sources/xcodeproj/PBXReferenceProxy.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Unbox
+
+/// A proxy for another object which might belong to another project
+/// contained in the same workspace of the document.
+/// This class is referenced by PBXTargetDependency.
+public class PBXReferenceProxy: PBXObject, Hashable {
+    
+    // MARK: - Attributes
+    
+    // Element file type
+    public var fileType: String
+    
+    // Element path.
+    public var path: String
+    
+    // Element remote reference.
+    public var remoteRef: String
+    
+    // Element source tree.
+    public var sourceTree: PBXSourceTree
+    
+    // MARK: - Init
+    
+    public init(reference: String,
+                fileType: String,
+                path: String,
+                remoteRef: String,
+                sourceTree: PBXSourceTree) {
+        self.fileType = fileType
+        self.path = path
+        self.remoteRef = remoteRef
+        self.sourceTree = sourceTree
+        super.init(reference: reference)
+    }
+    
+    /// Initializes the reference proxy with the element reference an a dictionary with its properties.
+    ///
+    /// - Parameters:
+    ///   - reference: element reference.
+    ///   - dictionary: dictionary with the element properties.
+    /// - Throws: an error in case any property is missing or the format is wrong.
+    public override init(reference: String, dictionary: [String: Any]) throws {
+        let unboxer = Unboxer(dictionary: dictionary)
+        self.fileType = try unboxer.unbox(key: "fileType")
+        self.path = try unboxer.unbox(key: "path")
+        self.remoteRef = try unboxer.unbox(key: "remoteRef")
+        self.sourceTree = try unboxer.unbox(key: "sourceTree")
+        try super.init(reference: reference, dictionary: dictionary)
+    }
+    
+    // MARK: - Hashable
+    
+    public static func == (lhs: PBXReferenceProxy,
+                           rhs: PBXReferenceProxy) -> Bool {
+        return lhs.reference == rhs.reference &&
+            lhs.fileType == rhs.fileType &&
+            lhs.path == rhs.path &&
+            lhs.remoteRef == rhs.remoteRef &&
+            lhs.sourceTree == rhs.sourceTree
+    }
+}
+
+// MARK: - PBXReferenceProxy
+extension PBXReferenceProxy: PlistSerializable {
+    
+    func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
+        var dictionary: [CommentedString: PlistValue] = [:]
+        dictionary["isa"] = .string(CommentedString(PBXVariantGroup.isa))
+        dictionary["fileType"] = .string(CommentedString(fileType))
+        dictionary["path"] = .string(CommentedString(path))
+        dictionary["remoteRef"] = .string(CommentedString(remoteRef, comment: "PBXContainerItemProxy"))
+        dictionary["sourceTree"] = sourceTree.plist()
+        return (key: CommentedString(self.reference, comment: path),
+                value: .dictionary(dictionary))
+    }
+    
+}

--- a/Tests/xcodeprojTests/PBXReferenceProxySpec.swift
+++ b/Tests/xcodeprojTests/PBXReferenceProxySpec.swift
@@ -1,0 +1,70 @@
+import Foundation
+import XCTest
+import xcodeproj
+
+final class PBXReferenceProxySpec: XCTestCase {
+    
+    var subject: PBXReferenceProxy!
+    
+    override func setUp() {
+        super.setUp()
+        self.subject = PBXReferenceProxy(reference: "ref",
+                                         fileType: "fileType",
+                                         path: "path",
+                                         remoteRef: "remoteRef",
+                                         sourceTree: .absolute)
+    }
+    
+    func test_init_initializesTheModelWithTheCorrectAttributes() {
+        XCTAssertEqual(subject.reference, "ref")
+        XCTAssertEqual(subject.fileType, "fileType")
+        XCTAssertEqual(subject.path, "path")
+        XCTAssertEqual(subject.remoteRef, "remoteRef")
+        XCTAssertEqual(subject.sourceTree, .absolute)
+    }
+    
+    func test_init_failsIfTheFileTypeIsMissing() {
+        var dictionary = testDictionary()
+        dictionary.removeValue(forKey: "fileType")
+        do {
+            _ = try PBXReferenceProxy(reference: "reference", dictionary: dictionary)
+            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+        } catch {}
+    }
+    
+    func test_init_failsIfThePathIsMissing() {
+        var dictionary = testDictionary()
+        dictionary.removeValue(forKey: "path")
+        do {
+            _ = try PBXReferenceProxy(reference: "reference", dictionary: dictionary)
+            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+        } catch {}
+    }
+    
+    func test_init_failsIfTheRemoteRefIsMissing() {
+        var dictionary = testDictionary()
+        dictionary.removeValue(forKey: "remoteRef")
+        do {
+            _ = try PBXReferenceProxy(reference: "reference", dictionary: dictionary)
+            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+        } catch {}
+    }
+    
+    func test_init_failsIfTheSourceTreeIsMissing() {
+        var dictionary = testDictionary()
+        dictionary.removeValue(forKey: "sourceTree")
+        do {
+            _ = try PBXReferenceProxy(reference: "reference", dictionary: dictionary)
+            XCTAssertTrue(false, "Expected to throw an error but it didn't")
+        } catch {}
+    }
+    
+    private func testDictionary() -> [String: Any] {
+        return [
+            "fileType": "fileType",
+            "path": "path",
+            "remoteRef": "remoteRef",
+            "sourceTree": "<absolute>"
+        ]
+    }
+}


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/xcodeproj/issues/78)

Solves https://github.com/carambalabs/xcodeproj/issues/78

### Short description
The model `PBXReferenceProxy` wasn't supported.

### Solution
Add `PBXReferenceProxy` model.

### Implementation
- [x] Add `PBXReferenceProxy` model.
- [x] Test model initialization.
- [x] Add `referenceProxies` to `PBSProj`

### GIF
![gif](https://media.giphy.com/media/nFptMetxIdCow/giphy.gif)
