### PR TITLE
Move PBXVariantGroup children property to Array

### DIFF
--- a/Sources/xcodeproj/PBXVariantGroup.swift
+++ b/Sources/xcodeproj/PBXVariantGroup.swift
@@ -7,7 +7,7 @@ public class PBXVariantGroup: PBXObject, Hashable {
     // MARK: - Attributes
     
     // The objects are a reference to a PBXFileElement element
-    public var children: Set<String>
+    public var children: [String]
     
     // The filename
     public var name: String
@@ -25,7 +25,7 @@ public class PBXVariantGroup: PBXObject, Hashable {
     ///   - name: name of the variant group
     ///   - sourceTree: the group source tree.
     public init(reference: String,
-                children: Set<String>,
+                children: [String],
                 name: String,
                 sourceTree: PBXSourceTree) {
         self.children = children


### PR DESCRIPTION
**Issue:** [Link](https://github.com/carambalabs/xcodeproj/issues/87)
Solves https://github.com/swift-xcode/xcodeproj/issues/87

### Short description
Update `PBXVariantGroup` children property to array.

### GIF
![gif](https://media.giphy.com/media/OOZLyBA9Euq2I/giphy.gif)
